### PR TITLE
[UI fixup] s/createApeVault/createCoVault

### DIFF
--- a/contracts/ApeProtocol/wrapper/beacon/ApeVaultFactory.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/ApeVaultFactory.sol
@@ -19,7 +19,7 @@ contract ApeVaultFactoryBeacon {
 		beacon = _beacon;
 	}
 
-	function createApeVault(address _token, address _simpleToken) external {
+	function createCoVault(address _token, address _simpleToken) external {
 		bytes memory data = abi.encodeWithSignature("init(address,address,address,address,address)", apeRegistry, _token, yearnRegistry, _simpleToken, msg.sender);
 		ApeBeacon proxy = new ApeBeacon(beacon, msg.sender, data);
 		vaultRegistry[address(proxy)] = true;

--- a/contracts/ApeProtocol/wrapper/beacon/mock/MockFactory.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/mock/MockFactory.sol
@@ -19,7 +19,7 @@ contract MockVaultFactoryBeacon {
 		beacon = _beacon;
 	}
 
-	function createApeVault() external {
+	function createCoVault() external {
 		bytes memory data = abi.encodeWithSignature("init()");
 		ApeBeacon proxy = new ApeBeacon(beacon, msg.sender, data);
 		vaultRegistry[address(proxy)] = true;

--- a/tests/test_ape_vault_beacon_registry.py
+++ b/tests/test_ape_vault_beacon_registry.py
@@ -24,7 +24,7 @@ def setup_protocol(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape
 def test_vault_creation(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, big_usdc, usdc, ApeVaultWrapperImplementation, minter):
     setup_protocol(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, minter)
     user = accounts[0]
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     assert ape_vault.owner() == user
     assert ape_vault.token() == usdc
@@ -37,7 +37,7 @@ def test_router(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_fa
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     assert ape_vault.owner() == user
     assert ape_vault.token() == usdc
@@ -60,7 +60,7 @@ def test_vault_exit(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ap
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
@@ -74,7 +74,7 @@ def test_vault_exit_underlying(ape_reg, ape_fee, ape_distro, ape_router_registry
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
@@ -89,7 +89,7 @@ def test_vault_withdraw_underlying(ape_reg, ape_fee, ape_distro, ape_router_regi
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
@@ -104,7 +104,7 @@ def test_vault_withdraw(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
@@ -124,7 +124,7 @@ def test_circle_allowance(ape_reg, ape_fee, ape_distro, ape_router_registry_beac
     amount = 20_000_000_000
     interval = 60 * 60 * 14 # 14 days
     epochs = 4
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_vault.updateAllowance(circle, usdc, 20_000_000_000, interval, epochs, 0,{'from':user})
     (debt, intervalStart, epochs) = ape_distro.currentAllowances(ape_vault, circle, token)
@@ -134,7 +134,7 @@ def test_circle_allowance(ape_reg, ape_fee, ape_distro, ape_router_registry_beac
 def test_vault_circle_admin(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, big_usdc, usdc, ApeVaultWrapperImplementation, minter, interface):
     setup_protocol(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, minter)
     user = accounts[0]
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     circle = '0x1'
     ape_vault.updateCircleAdmin(circle, user, {'from':user})
@@ -145,7 +145,7 @@ def test_vault_circle_admin(ape_reg, ape_fee, ape_distro, ape_router_registry_be
 def test_tap_revert(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, big_usdc, usdc, ApeVaultWrapperImplementation, minter, interface):
     setup_protocol(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_factory_registry_beacon, minter)
     user = accounts[0]
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     circle = '0x1'
     with reverts(''):

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -28,7 +28,7 @@ def test_root_upload(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, a
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -54,7 +54,7 @@ def test_root_upload_epoch_revert(ape_reg, ape_fee, ape_distro, ape_router_regis
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -83,7 +83,7 @@ def test_allowance_revert(ape_reg, ape_fee, ape_distro, ape_router_registry_beac
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -116,7 +116,7 @@ def test_allowance_interval(ape_reg, ape_fee, ape_distro, ape_router_registry_be
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -155,7 +155,7 @@ def test_allowance_one_time(ape_reg, ape_fee, ape_distro, ape_router_registry_be
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -187,7 +187,7 @@ def test_allowance_start_time_future(ape_reg, ape_fee, ape_distro, ape_router_re
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -222,7 +222,7 @@ def test_claiming(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -270,7 +270,7 @@ def test_claiming_many(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon,
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -333,7 +333,7 @@ def test_allowance_monthly(ape_reg, ape_fee, ape_distro, ape_router_registry_bea
     amount = 1_000_000_000_000
     usdc.transfer(user, amount, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     ape_router_registry_beacon.delegateDeposit(ape_vault, usdc, amount, {'from':user})
     usdc_vault = interface.IERC20('0xa354F35829Ae975e850e23e9615b11Da1B3dC4DE')
@@ -386,7 +386,7 @@ def test_attack(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_fa
     deposit = 11_000_000_000_000
     usdc.transfer(user, deposit, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     # funding more than necessary
     amount = 10_000_000_000_000
@@ -402,7 +402,7 @@ def test_attack(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_fa
     ape_distro.uploadEpochRoot(ape_vault, circle, token, root, grant, TAP_BASE, {'from': user})
 
     # create rogue contract
-    r0gue_tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':accounts[6]})
+    r0gue_tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':accounts[6]})
     rogue_ape_vault = ApeVaultWrapperImplementation.at(r0gue_tx.new_contracts[0])
     rogue_circle = '0x2'
     token = usdc_vault
@@ -425,7 +425,7 @@ def test_attack_2(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_
     deposit = 11_000_000_000_000
     usdc.transfer(user, deposit, {'from':big_usdc})
     usdc.approve(ape_router_registry_beacon, 2 ** 256 -1, {'from':user})
-    tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     # funding more than necessary
     amount = 10_000_000_000_000
@@ -441,7 +441,7 @@ def test_attack_2(ape_reg, ape_fee, ape_distro, ape_router_registry_beacon, ape_
     ape_distro.uploadEpochRoot(ape_vault, circle, token, root, grant, TAP_BASE, {'from': user})
 
     # create rogue contract
-    r0gue_tx = ape_factory_registry_beacon.createApeVault(usdc, '0x0000000000000000000000000000000000000000', {'from':accounts[6]})
+    r0gue_tx = ape_factory_registry_beacon.createCoVault(usdc, '0x0000000000000000000000000000000000000000', {'from':accounts[6]})
     rogue_ape_vault = ApeVaultWrapperImplementation.at(r0gue_tx.new_contracts[0])
     rogue_circle = '0x1'
     token = usdc_vault

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -31,7 +31,7 @@ def test_migration(mock_ape_reg, mock_ape_fee, mock_ape_distro, mock_ape_router_
     mock_token.approve(mock_ape_router_beacon, 2 ** 256 -1, {'from':user})
     new_vault_tx = mock_yearn_vault_factories.createVault(mock_token, 'yvhello', 'yvh',{'from':user})
     vault = MockVault.at(new_vault_tx.new_contracts[0])
-    tx = mock_ape_factory_beacon.createApeVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = mock_ape_factory_beacon.createCoVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     mock_ape_router_beacon.delegateDeposit(ape_vault, mock_token, amount, {'from':user})
     assert vault.balanceOf(ape_vault) >= amount

--- a/tests/test_registry_implementation.py
+++ b/tests/test_registry_implementation.py
@@ -5,7 +5,7 @@ import web3
 
 def test_normal_implementation(mock_factory_registry_beacon, accounts, ApeVaultWrapperImplementation1):
 	user = accounts[0]
-	tx = mock_factory_registry_beacon.createApeVault({'from':user})
+	tx = mock_factory_registry_beacon.createCoVault({'from':user})
 	imp = ApeVaultWrapperImplementation1.at(tx.new_contracts[0])
 	assert imp.someValue() == 0
 	assert imp.version() == 1
@@ -14,7 +14,7 @@ def test_normal_implementation(mock_factory_registry_beacon, accounts, ApeVaultW
 
 def test_upgrade(mock_factory_registry_beacon, mock_registry_beacon, accounts, ApeVaultWrapperImplementation1, implementation2, implementation3, minter):
 	user = accounts[0]
-	tx = mock_factory_registry_beacon.createApeVault({'from':user})
+	tx = mock_factory_registry_beacon.createCoVault({'from':user})
 	imp = ApeVaultWrapperImplementation1.at(tx.new_contracts[0])
 	imp.write({'from':user})
 	assert imp.someValue() == 11
@@ -37,7 +37,7 @@ def test_opt_out(mock_factory_registry_beacon, mock_registry_beacon, accounts, A
 	user = accounts[0]
 	disc = ApeBeacon.deploy(mock_registry_beacon, user, '0xe1c7392a', {'from':user})
 	pref_call = disc.setBeaconDeploymentPrefs.encode_input(1)
-	tx = mock_factory_registry_beacon.createApeVault({'from':user})
+	tx = mock_factory_registry_beacon.createCoVault({'from':user})
 	imp = ApeVaultWrapperImplementation1.at(tx.new_contracts[0])
 	imp.write({'from':user})
 	assert imp.someValue() == 11
@@ -68,7 +68,7 @@ def test_opt_out_then_opt_in(mock_factory_registry_beacon, mock_registry_beacon,
 	user = accounts[0]
 	disc = ApeBeacon.deploy(mock_registry_beacon, user, '0xe1c7392a', {'from':user})
 	pref_call = disc.setBeaconDeploymentPrefs.encode_input(1)
-	tx = mock_factory_registry_beacon.createApeVault({'from':user})
+	tx = mock_factory_registry_beacon.createCoVault({'from':user})
 	add = tx.new_contracts[0]
 	imp = ApeVaultWrapperImplementation1.at(add)
 	imp.write({'from':user})

--- a/tests/test_tap_no_fork.py
+++ b/tests/test_tap_no_fork.py
@@ -31,7 +31,7 @@ def test_tap_profit(mock_ape_reg, mock_ape_fee, mock_ape_distro, mock_ape_router
     mock_token.approve(mock_ape_router_beacon, 2 ** 256 -1, {'from':user})
     new_vault_tx = mock_yearn_vault_factories.createVault(mock_token, 'yvhello', 'yvh',{'from':user})
     vault = MockVault.at(new_vault_tx.new_contracts[0])
-    tx = mock_ape_factory_beacon.createApeVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = mock_ape_factory_beacon.createCoVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     mock_ape_router_beacon.delegateDeposit(ape_vault, mock_token, amount, {'from':user})
     assert vault.balanceOf(ape_vault) >= amount
@@ -65,7 +65,7 @@ def test_expected_profit_revert(mock_ape_reg, mock_ape_fee, mock_ape_distro, moc
     mock_token.approve(mock_ape_router_beacon, 2 ** 256 -1, {'from':user})
     new_vault_tx = mock_yearn_vault_factories.createVault(mock_token, 'yvhello', 'yvh',{'from':user})
     vault = MockVault.at(new_vault_tx.new_contracts[0])
-    tx = mock_ape_factory_beacon.createApeVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = mock_ape_factory_beacon.createCoVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     mock_ape_router_beacon.delegateDeposit(ape_vault, mock_token, amount, {'from':user})
     assert vault.balanceOf(ape_vault) >= amount
@@ -97,7 +97,7 @@ def test_bad_harvest_reset_value(mock_ape_reg, mock_ape_fee, mock_ape_distro, mo
     mock_token.approve(mock_ape_router_beacon, 2 ** 256 -1, {'from':user})
     new_vault_tx = mock_yearn_vault_factories.createVault(mock_token, 'yvhello', 'yvh',{'from':user})
     vault = MockVault.at(new_vault_tx.new_contracts[0])
-    tx = mock_ape_factory_beacon.createApeVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
+    tx = mock_ape_factory_beacon.createCoVault(mock_token, '0x0000000000000000000000000000000000000000', {'from':user})
     ape_vault = ApeVaultWrapperImplementation.at(tx.new_contracts[0])
     mock_ape_router_beacon.delegateDeposit(ape_vault, mock_token, amount, {'from':user})
     assert vault.balanceOf(ape_vault) == amount


### PR DESCRIPTION
Change contract name from 'createApeVault' to 'createCoVault' to match branding in our frontend app, as
this is shown to users during contract interaction.

No changes to any contract functionality.