### PR TITLE
rename contracts

### DIFF
--- a/contracts/ApeProtocol/ApeDistributor.sol
+++ b/contracts/ApeProtocol/ApeDistributor.sol
@@ -65,7 +65,7 @@ contract ApeDistributor is ApeAllowanceModule {
 		uint8 _tapType,
 		bytes32 _root
 	) internal {
-		require(ApeVaultFactoryBeacon(ApeRegistry(registry).factory()).vaultRegistry(_vault), "ApeDistributor: Vault does not exist");
+		require(ApeVaultFactory(ApeRegistry(registry).factory()).vaultRegistry(_vault), "ApeDistributor: Vault does not exist");
 		bool isOwner = ApeVaultWrapperImplementation(_vault).owner() == msg.sender;
 		require(vaultApprovals[_vault][_circle] == msg.sender || isOwner, "ApeDistributor: Sender not approved");
 		

--- a/contracts/ApeProtocol/ApeRouter.sol
+++ b/contracts/ApeProtocol/ApeRouter.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.2;
 
 import {VaultAPI, BaseWrapperImplementation, RegistryAPI} from "./wrapper/beacon/BaseWrapperImplementation.sol";
-import {ApeVaultFactoryBeacon} from "./wrapper/beacon/ApeVaultFactory.sol";
+import {ApeVaultFactory} from "./wrapper/beacon/ApeVaultFactory.sol";
 import {ApeVaultWrapperImplementation} from "./wrapper/beacon/ApeVault.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -30,7 +30,7 @@ contract ApeRouter is TimeLock {
 		VaultAPI vault = VaultAPI(RegistryAPI(yearnRegistry).latestVault(_token));
 		require(address(vault) != address(0), "ApeRouter: No vault for token");
 		require(address(vault) == _yvToken, "ApeRouter: yvTokens don't match");
-		require(ApeVaultFactoryBeacon(apeVaultFactory).vaultRegistry(_apeVault), "ApeRouter: Vault does not exist");
+		require(ApeVaultFactory(apeVaultFactory).vaultRegistry(_apeVault), "ApeRouter: Vault does not exist");
 		require(address(vault) == address(ApeVaultWrapperImplementation(_apeVault).vault()), "ApeRouter: yearn Vault not identical");
 
 		IERC20(_yvToken).safeTransferFrom(msg.sender, _apeVault, _amount);
@@ -42,7 +42,7 @@ contract ApeRouter is TimeLock {
 	function delegateDeposit(address _apeVault, address _token, uint256 _amount) external returns(uint256 deposited) {
 		VaultAPI vault = VaultAPI(RegistryAPI(yearnRegistry).latestVault(_token));
 		require(address(vault) != address(0), "ApeRouter: No vault for token");
-		require(ApeVaultFactoryBeacon(apeVaultFactory).vaultRegistry(_apeVault), "ApeRouter: Vault does not exist");
+		require(ApeVaultFactory(apeVaultFactory).vaultRegistry(_apeVault), "ApeRouter: Vault does not exist");
 		require(address(vault) == address(ApeVaultWrapperImplementation(_apeVault).vault()), "ApeRouter: yearn Vault not identical");
 
 		IERC20(_token).safeTransferFrom(msg.sender, address(this), _amount);
@@ -66,7 +66,7 @@ contract ApeRouter is TimeLock {
 	function delegateWithdrawal(address _recipient, address _apeVault, address _token, uint256 _shareAmount, bool _underlying) external{
 		VaultAPI vault = VaultAPI(RegistryAPI(yearnRegistry).latestVault(_token));
 		require(address(vault) != address(0), "ApeRouter: No vault for token");
-		require(ApeVaultFactoryBeacon(apeVaultFactory).vaultRegistry(msg.sender), "ApeRouter: Vault does not exist");
+		require(ApeVaultFactory(apeVaultFactory).vaultRegistry(msg.sender), "ApeRouter: Vault does not exist");
 		require(address(vault) == address(ApeVaultWrapperImplementation(_apeVault).vault()), "ApeRouter: yearn Vault not identical");
 
 		if (_underlying)

--- a/contracts/ApeProtocol/wrapper/beacon/ApeUpgradeableBeacon.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/ApeUpgradeableBeacon.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.2;
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "../../TimeLock.sol";
 
-contract ApeUgradeableBeacon is UpgradeableBeacon, TimeLock {
+contract ApeUpgradeableBeacon is UpgradeableBeacon, TimeLock {
 
 	constructor(address _apeVault, uint256 _minDelay) UpgradeableBeacon(_apeVault) TimeLock(_minDelay) {}
 

--- a/contracts/ApeProtocol/wrapper/beacon/ApeVaultFactory.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/ApeVaultFactory.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.2;
 
 import "./ApeVault.sol";
-import "./ApeBeacon.sol";
+import "./VaultProxy.sol";
 
-contract ApeVaultFactoryBeacon {
+contract ApeVaultFactory {
 	mapping(address => bool) public vaultRegistry;
 
 	address public yearnRegistry;
@@ -21,7 +21,7 @@ contract ApeVaultFactoryBeacon {
 
 	function createCoVault(address _token, address _simpleToken) external {
 		bytes memory data = abi.encodeWithSignature("init(address,address,address,address,address)", apeRegistry, _token, yearnRegistry, _simpleToken, msg.sender);
-		ApeBeacon proxy = new ApeBeacon(beacon, msg.sender, data);
+		VaultProxy proxy = new VaultProxy(beacon, msg.sender, data);
 		vaultRegistry[address(proxy)] = true;
 		emit VaultCreated(address(proxy));
 	}

--- a/contracts/ApeProtocol/wrapper/beacon/VaultBeacon.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/VaultBeacon.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
 import "../../TimeLock.sol";
 
-contract ApeRegistryBeacon is TimeLock {
+contract VaultBeacon is TimeLock {
 
 	mapping(uint256 => address) public deployments;
 	uint256 public deploymentCount;
@@ -15,7 +15,7 @@ contract ApeRegistryBeacon is TimeLock {
 	event NewImplementationPushed(address newImplementation);
 
 	constructor(address _apeVault, uint256 _minDelay) TimeLock(_minDelay) {
-		require(Address.isContract(_apeVault), "ApeRegistryBeacon: implementaion is not a contract");
+		require(Address.isContract(_apeVault), "VaultBeacon: implementation is not a contract");
 		deployments[++deploymentCount] = _apeVault;
 	}
 
@@ -37,7 +37,7 @@ contract ApeRegistryBeacon is TimeLock {
 	}
 
 	function pushNewImplementation(address _newImplementation) public itself {
-		require(Address.isContract(_newImplementation), "ApeRegistryBeacon: implementaion is not a contract");
+		require(Address.isContract(_newImplementation), "VaultBeacon: implementaion is not a contract");
 		deployments[++deploymentCount] = _newImplementation;
 		emit NewImplementationPushed(_newImplementation);
 	}

--- a/contracts/ApeProtocol/wrapper/beacon/VaultProxy.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/VaultProxy.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.2;
 
 import "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
-import "./ApeRegistryBeacon.sol";
+import "./VaultBeacon.sol";
 
-contract ApeBeacon is BeaconProxy {
+contract VaultProxy is BeaconProxy {
 	bytes32 private constant _OWNER_SLOT = 0xa7b53796fd2d99cb1f5ae019b54f9e024446c3d12b483f733ccc62ed04eb126a;
 
 	event ProxyOwnershipTransferred(address newOwner);
@@ -32,6 +32,6 @@ contract ApeBeacon is BeaconProxy {
 
 	function setBeaconDeploymentPrefs(uint256 _value) external {
 		require(msg.sender == proxyOwner());
-		ApeRegistryBeacon(_beacon()).setDeploymentPrefs(_value);
+		VaultBeacon(_beacon()).setDeploymentPrefs(_value);
 	}
 }

--- a/contracts/ApeProtocol/wrapper/beacon/mock/MockFactory.sol
+++ b/contracts/ApeProtocol/wrapper/beacon/mock/MockFactory.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.2;
 
 import "./MockVault.sol";
-import "../ApeBeacon.sol";
+import "../VaultProxy.sol";
 
 contract MockVaultFactoryBeacon {
 	mapping(address => bool) public vaultRegistry;
@@ -21,7 +21,7 @@ contract MockVaultFactoryBeacon {
 
 	function createCoVault() external {
 		bytes memory data = abi.encodeWithSignature("init()");
-		ApeBeacon proxy = new ApeBeacon(beacon, msg.sender, data);
+		VaultProxy proxy = new VaultProxy(beacon, msg.sender, data);
 		vaultRegistry[address(proxy)] = true;
 		emit VaultCreated(address(proxy));
 	}


### PR DESCRIPTION
fix typo:
ApeUgradeableBeacon -> ApeUpgradeableBeacon

rename for clarity:
ApeRegistryBeacon -> VaultBeacon
ApeBeacon -> VaultProxy
ApeVaultFactoryBeacon -> ApeVaultFactory